### PR TITLE
Fixed a bug causing problems with certain properties not being set

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -73,6 +73,10 @@ function processEvent(event) {
         $set_once: {
           initial_source: "direct",
           initial_referrer_parser: "direct_and_own_domains",
+          initial_medium: "undefined",
+          initial_campaign: "undefined",
+          initial_content: "undefined",
+          initial_term: "undefined",
         },
       },
     }
@@ -109,6 +113,8 @@ function processEvent(event) {
         initial_source: referrerData.source.toLowerCase(),
         initial_term: searchQuery,
         initial_referrer_parser: "snowplow",
+        initial_campaign: "undefined",
+        initial_content: "undefined",
       },
     },
   }


### PR DESCRIPTION
Fixed a bug causing problems with certain properties not being set and messing with the statistics. The specific problem was that if a user's `set_once` properties were being set by one sort event, sometimes not all were actually set and if in the future they got to the site via another sort of event, other `set_once` properties would be set causing confusion.